### PR TITLE
Emergency Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-playlist-info",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Youtube playlist information fetcher.",
   "main": "./src/index.js",
   "types": "./typings/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-playlist-info",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Youtube playlist information fetcher.",
   "main": "./src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -20,15 +20,16 @@ function playlistInfoRecursive(playlistId, callStackSize, pageToken, currentItem
   });
 }
 
-module.exports = function playlistInfo(apiKey, playlistId, {maxResults}) {
+module.exports = function playlistInfo(apiKey, playlistId, options) {
   return new Promise((resolve, reject) => {
     if (!apiKey) return reject(new Error('No API Key Provided'));
     if (!playlistId) return reject(new Error('No Playlist ID Provided'));
+    if (!options) options = {};
     youtube.authenticate({
       type: 'key',
       key: apiKey
     });
-    playlistInfoRecursive(playlistId, 0, null, [], maxResults, (err, list) => {
+    playlistInfoRecursive(playlistId, 0, null, [], options.maxResults || null, (err, list) => {
       if (err) return reject(err);
       return resolve(list);
     });


### PR DESCRIPTION
Currently, if you do not include an object for the options (ex. {}), it will error the module. This fixes that to where you don't require the object.

How to cause the error: (Just don't include options)
```js
playlistInfo(process.env.API_KEY, 'PLV34fyAxhmQPnz2obH3cDPjY-whXGBKRp').then(playlistItems => {
  console.log(playlistItems);
  console.log(playlistItems.length);
}).catch(console.error);
```

This fixes that.